### PR TITLE
1.9 corrections for chest refill

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,24 +33,106 @@ This is not just another Hunger Games plugin. This plugin aims to bring a fully 
  - Events API - Economy, Kits + More!
 Plus many, many more features included in this plugin!
 
-Next Update
+Original Website
+----------------
+The documentation for the original plugin can be found at
+http://dev.bukkit.org/bukkit-plugins/survival-games/pages/setup/installing/
+
+Note that this updated plugin also has Bandages, and a modified and extended Chest Refil system.
+
+Permissions
 -----------
- - All known bugs, fixed.
- - Kits menu & config
- - Death match
- - and more!
-Note: Devs and important people of this plugin have colored names on lobby signs
+The players should be in Survival mode, and need to have permissions to place, interact with and break blocks.  You can define which blocks may be placed and broken in the `config.yml` file.
 
-Read Before Posting!
---------------------
- - A full tutorial on kits, economy and new features will be released soon!
- - /sg setlobbywall was changed to /sg addwall <arena> in versions 0.5.0 and above!
- - Need support? Find me on IRC @ irc.esper.net #survivalgames or use the webchat: http://webchat.esper.net/?channels=survivalgames  
-*New Permissions:*
+To join arena number 1, players need to have the following permissions:
 
-If you have for example 6 arenas, and you want every player to be able to join all arenas, give each rank the following permissions:
-
- - sg.arenas.join.<arena#> (Replace <arena#> with the arena number.)
+ - sg.arenas.join.1  - Allows player to join lobby 1
  - sg.arena.join
- - sg.arena.vote
- - sg.lobby.join
+ - sg.arena.vote - Allows player to vote for start
+ - sg.arena.spectate - Allows a user to spectate a game 
+ 
+If you have problems with players being unable to join a game, make sure that there is no '.all' or '.*' permission for the 'join' group.  Grant permissions explicitly.
+
+Staff can also have the following permissions:
+
+ - sg.arena.forcestart - Allows the user to Start Sg (/sg start)
+ - sg.arena.disable - Allows the user to disable an arena
+ - sg.arena.enable - Allows the user to enable an arena
+ - sg.arena.nocmdblock - Allows user to bypass ingame cmd block 
+
+To create an Arena and Lobby, you should be an Operator or have the following:
+
+ - sg.arena.create - Allows the user to create an arena
+ - sg.arena.setarenaspawns - Allows user to set spawns
+ - sg.arena.resetspawns - Allows the user to reset all spawnpoints
+ - sg.arena.delete - Allows a user to delete an arena
+ - sg.lobby.set - Allows the user to set the lobby spawn and wall 
+
+Creating a World
+----------------
+There are several Survival Games worlds you can download, or you can of course make your own.  The World should have PVP enabled, and be in Survival mode.  You can optionally disable spawning monsters; this may be a good idea as players can otherwise be attacked while waiting for the game to start.
+
+You should have some sort of wall around your playing arena to prevent players from leaving.  Outside, you need to have a Lobby area somewhere for players to gather and select an Arena.
+ 
+Creating a Lobby
+----------------
+Create your lobby are somewhere outside of the Arena.  Generally, you will want to use WorldGuard or similar to protect it from damage, and disable PvP within the lobby, though this is optional.  The Lobby will usually have your World spawn point, or be connected to it somehow.
+
+Stand in the Lobby in the location you want people to respawn after a game, and run `/sg setlobbyspawn`
+
+You can create a Wall for an Arena (once you have made the arena) like this:
+ -  place two Wall Signs next to each other
+ -  select them (using the WorldEdit Wand and left-click on the first sign, right-click on the second)
+ -  Use the command `/sg addwall X` where X is the Arena number -- if you only have one Arena, this will be 1.
+
+Creating an arena
+-----------------
+This required the WorldEdit wand.
+
+Use `/wand` to obtain the WorldEdit wand (usually, a golden axe).  With the wand, select the entire arena area by left-clicking one corner, and right-clicking the opposite corner.  Don't forget to cover all the vertical area as well!  You can use `//expand vert` to expand your selected area from bedrock to the top of the sky if you want; see the WorldEdit documentation for other WorldEdit commands.
+
+Once selected, use `/sg creatarena` to create the arena, and find out its number.  You can use `/sg listarenas` to list all the currently defined Arenas.
+
+The next thing to do is to define the spawn points for the arena.  Use `/sg setspawn 1` to set your current location to be spawn point number 1.  You can then use `/sg setspawn next` repeatedly to keep adding new spawn points.  The number of spawn points is, of course, the maximum number of players for your arena.
+
+Now you have an arena, you need to have a Wallsign for it in the Lobby.  See the above section for help on doing this.
+
+Defining Kits
+-------------
+To be added.
+
+Bandages
+--------
+The 'paper' item acts in-game as a Bandage.  Right-clicking when holding a piece of paper will add 5 hearts and destroy the paper.
+
+Automatic Chest Refills
+-----------------------
+Chests will be randomly filled at the time they are first opened.  If the item in Slot 0 of the chest is a wool block, then the Base level of the chest will be set to the colour code of the wool plus 1; otherwise, it will default to using Level 1.
+
+A chest Base Level will be randomly increased by up to `chest.maxincrese` in the chest.yml file, with a chance of 1 in `chest.ratio` of going up a level.  When a level is determined, then a random number between `chest.min` and `chest.max` is selected and this many random items are picked from the `chest.lvlX` group (for level X).  The same item may be picked multiple times.
+
+If the `clear-chest` option in `config.yml` is true, then the chest is emptied before random items are selected.  Otherwise, only the Wool Block (if present) is removed, and the other items are left in place.
+
+Items defined in the `chest.lvlX` sections may be given in multiple forms, optionally quoted.  The identifier can be given as a name or as a number, and all fields after the quantity are optional.  Here are some examples:
+- 236,1   (Item number and quantity)
+- diamond_sword,1   (Item name and quantity)
+- dye,5,2   (Item name/number, quantity, and DV)
+- "diamond_sword,1,0,sharpness:2 looting:1"  (Item name/number, quantity, DV, enchantment list)
+- "iron_sword,1,0,sharpness:2 fire:5,Excalibur"  (Item name/number, quantity, DV, enchantment list, and name)
+The Enchantment names are the lower-case class names from Bukkit without underscores.
+
+If the `restock-chest` option in config.yml is set, chests will be reset (new random items added) at the first midnight.  If `restock-chest-repeat` is set, this will be done every midnight.
+
+Chests will be reset at the end of the game, along with any blocks which have been changed.
+
+Commands
+--------
+To be added.
+
+Playing the game
+----------------
+Players should start in the Lobby.  They right-click on the sign, and this takes them into the game (or places them in the queue if the game is already full or in progress).
+
+In the `config.yml` you can set `auto-start-players` to be the minimum number of players required to automatically start the game.  If there are fewer players, then players can use `/sg vote` until more than `auto-start-vote` percent of them have voted, at which point the game will start.
+
+Players can use `/sg leave` to leave the game early; they can use `/sg leavequeue` or `/sg lq` to leave the queue.

--- a/src/main/java/org/mcsg/survivalgames/CommandHandler.java
+++ b/src/main/java/org/mcsg/survivalgames/CommandHandler.java
@@ -12,31 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.mcsg.survivalgames.MessageManager.PrefixType;
-import org.mcsg.survivalgames.commands.AddWall;
-import org.mcsg.survivalgames.commands.CreateArena;
-import org.mcsg.survivalgames.commands.DelArena;
-import org.mcsg.survivalgames.commands.Disable;
-import org.mcsg.survivalgames.commands.Enable;
-import org.mcsg.survivalgames.commands.Flag;
-import org.mcsg.survivalgames.commands.ForceStart;
-import org.mcsg.survivalgames.commands.Join;
-import org.mcsg.survivalgames.commands.Leave;
-import org.mcsg.survivalgames.commands.LeaveQueue;
-import org.mcsg.survivalgames.commands.ListArenas;
-import org.mcsg.survivalgames.commands.ListPlayers;
-import org.mcsg.survivalgames.commands.Reload;
-import org.mcsg.survivalgames.commands.ResetArena;
-import org.mcsg.survivalgames.commands.ResetSpawns;
-import org.mcsg.survivalgames.commands.SetLobbySpawn;
-import org.mcsg.survivalgames.commands.SetLobbyWall;
-import org.mcsg.survivalgames.commands.SetSpawn;
-import org.mcsg.survivalgames.commands.SetStatsWall;
-import org.mcsg.survivalgames.commands.Spectate;
-import org.mcsg.survivalgames.commands.SubCommand;
-import org.mcsg.survivalgames.commands.Teleport;
-import org.mcsg.survivalgames.commands.Test;
-import org.mcsg.survivalgames.commands.Vote;
-
+import org.mcsg.survivalgames.commands.*;
 
 
 public class CommandHandler implements CommandExecutor {
@@ -75,6 +51,7 @@ public class CommandHandler implements CommandExecutor {
 		commands.put("listarenas", new ListArenas());
 		commands.put("tp", new Teleport());
 		commands.put("reload", new Reload());
+		commands.put("refill", new Refill());
 		commands.put("setstatswall", new SetStatsWall());
 		commands.put("resetarena", new ResetArena());
 //		commands.put("test", new Test());
@@ -105,6 +82,7 @@ public class CommandHandler implements CommandExecutor {
 		helpinfo.put("list", 1);
 		helpinfo.put("listarenas", 1);
 		helpinfo.put("reload", 3);
+		helpinfo.put("refill", 3);
 		helpinfo.put("resetarena", 3);
 		helpinfo.put("setstatswall", 1);
 

--- a/src/main/java/org/mcsg/survivalgames/GameManager.java
+++ b/src/main/java/org/mcsg/survivalgames/GameManager.java
@@ -321,6 +321,7 @@ public class GameManager {
 	}
 
 	public void gameEndCallBack(int id) {
+		// Chest reset is now done by a separate class
 		//getGame(id).setRBStatus("clearing chest");
 		//openedChest.put(id, new HashMap < Block, ItemStack[] > ());
 	}

--- a/src/main/java/org/mcsg/survivalgames/commands/Refill.java
+++ b/src/main/java/org/mcsg/survivalgames/commands/Refill.java
@@ -1,0 +1,49 @@
+package org.mcsg.survivalgames.commands;
+
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.mcsg.survivalgames.Game;
+import org.mcsg.survivalgames.GameManager;
+import org.mcsg.survivalgames.MessageManager;
+import org.mcsg.survivalgames.MessageManager.PrefixType;
+import org.mcsg.survivalgames.logging.QueueManager;
+import org.mcsg.survivalgames.SettingsManager;
+
+public class Refill implements SubCommand {
+
+	MessageManager msgmgr = MessageManager.getInstance();
+
+	public boolean onCommand(Player player, String[] args) {
+
+		if (!player.hasPermission(permission()) && !player.isOp()) {
+			MessageManager.getInstance().sendFMessage(PrefixType.ERROR, "error.nopermission", player);
+			return true;
+		}
+		int game = -1;
+		if(args.length >= 1){
+			game = Integer.parseInt(args[0]);
+
+		}
+		else
+			game  = GameManager.getInstance().getPlayerGameId(player);
+		if(game == -1){
+			MessageManager.getInstance().sendFMessage(PrefixType.ERROR, "error.notingame", player);
+			return true;
+		}
+
+		QueueManager.getInstance().restockChests(game);
+		
+		msgmgr.sendFMessage(PrefixType.INFO, "game.refill", player, "arena-" + game);
+
+		return true;
+	}
+
+	public String help(Player p) {
+		return "/sg refill [<id>] " + SettingsManager.getInstance().getMessageConfig().getString("messages.help.refill", "Refill the chests");
+	}
+
+	public String permission() {
+		return "sg.arena.refill";
+	}
+}

--- a/src/main/java/org/mcsg/survivalgames/commands/Reload.java
+++ b/src/main/java/org/mcsg/survivalgames/commands/Reload.java
@@ -58,7 +58,7 @@ public class Reload implements SubCommand{
 
 	public String help(Player p) {
 		// TODO Auto-generated method stub
-		return null;
+		return "/sg reload [settings|game|all]  Reload module configuration";
 	}
 
 	public String permission() {

--- a/src/main/java/org/mcsg/survivalgames/events/ChestReplaceEvent.java
+++ b/src/main/java/org/mcsg/survivalgames/events/ChestReplaceEvent.java
@@ -76,17 +76,23 @@ public class ChestReplaceEvent implements Listener{
     				            	if( i == null ) { continue; }
     				                int l = rand.nextInt(26);
     				                int attempt = 0;
-    				                if( inv.getSize() > 25 ) {
+    				                if( inv.firstEmpty() < 0 ) {
     				                	SurvivalGames.info("Chest at "+blk.getX()+","+blk.getY()+","+blk.getZ()+" is full: cannot add items");
     				                	break; 
     				                }
-    				                while((inv.getItem(l) != null) && (attempt<10))  { // warning!  Chest may be full!
+    				                while((inv.getItem(l) != null) && (attempt<20))  { // warning!  Chest may be full!
+    				                	SurvivalGames.debug("Look again, slot "+l+" is already occupied!");
     				                    l = rand.nextInt(26);
     				                    attempt++;
     				                }
     				                
     				                try {
-    				                	if(attempt<10) { inv.setItem(l, i); }
+    				                	if(attempt<20) { 
+    				                		inv.setItem(l, i); 
+    				                	} else {
+        				                	SurvivalGames.info("Chest at "+blk.getX()+","+blk.getY()+","+blk.getZ()+" is too full: cannot add items");
+        				                	break; 
+        				                }
     				                } catch ( Exception e2 ) {
     				                	SurvivalGames.error("Problem putting item "+ i.getType().name() + " into slot "+l);
     				                	SurvivalGames.error("Java says: "+e2.getMessage());

--- a/src/main/java/org/mcsg/survivalgames/logging/QueueManager.java
+++ b/src/main/java/org/mcsg/survivalgames/logging/QueueManager.java
@@ -196,7 +196,7 @@ public class QueueManager {
 
 		public void run(){
 			HashMap<Block,ItemStack[]>openedChests = GameManager.openedChest.get(id);
-			
+			if( openedChests == null ) { SurvivalGames.debug("Nothing to reset for id "+id); return; }
 			SurvivalGames.debug("Resetting saved chests content for game "+id);
 			for( Block chest: openedChests.keySet() ) {
 				BlockState bs = chest.getState();

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -25,6 +25,7 @@ messages:
     started: '&aStarted game {$arena}.'
     nopermission: '&cYou do not have permission to join arena {$arena}'
     reset: '&cArena {$arena} has been reset!'
+    refill: '&cChests in arena {$arena} refilled!'
   info:
     success: '&e{$command} &aexecuted successfuly.'
     unsuccess: '&e{$command} &cexecuted unsuccessfuly.'


### PR DESCRIPTION
- Corrections to make chest refill work with both 1.8 and 1.9 Bukkit API
- Add /sg refill admin command to make testing of chest refill easier

Tested with Bukkit 1.9 and Minecraft 1.9
Chest refill without clear, with and without wool blocks
