### PR TITLE
Fix Typos & Set Lobby Spawn Message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ nb-configuration.xml
 /update
 /worlds
 
+# JRebel #
+###########
+rebel.xml
+reble-remote.xml

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Note that this updated plugin also has Bandages, and a modified and extended Che
 
 Permissions
 -----------
-<<<<<<< HEAD
 The players should be in Survival mode, and need to have permissions to place, interact with and break blocks.  You can define which blocks may be placed and broken in the `config.yml` file.
 
 To join arena number 1, players need to have the following permissions:
@@ -65,7 +64,6 @@ Read Before Posting!
 If you have for example 6 arenas, and you want every player to be able to join all arenas, give each rank the following permissions:
 
  - sg.arena.join.<arena#> (Replace <arena#> with the arena number.)
->>>>>>> 5e6b786fe5675dca703cbf8871927e46fe3b6b8b
  - sg.arena.join
  - sg.arena.vote - Allows player to vote for start
  - sg.arena.spectate - Allows a user to spectate a game 

--- a/src/main/java/org/mcsg/survivalgames/MessageManager.java
+++ b/src/main/java/org/mcsg/survivalgames/MessageManager.java
@@ -42,9 +42,9 @@ public class MessageManager {
 	 * Loads a Message from messages.yml, converts its colors and replaces vars in the form of {$var} with its correct values, 
 	 * then sends to the player, adding the correct prefix 
 	 *  
-	 * @param type
-	 * @param input
-	 * @param player
+	 * @param type Type of message to send
+	 * @param input What message you want to send from messages.yml
+	 * @param player Player you want to send message to
 	 * @param vars
 	 */
 	public void sendFMessage(PrefixType type, String input, Player player, String ... args) {
@@ -61,11 +61,11 @@ public class MessageManager {
 	/**
 	 * SendMessage
 	 * 
-	 * Sends a pre formated message from the plugin to a player, adding correct prefix first
+	 * Sends a pre formatted message from the plugin to a player, adding correct prefix first
 	 * 
-	 * @param type
-	 * @param msg
-	 * @param p
+	 * @param type Type of message to send
+	 * @param msg The message you want to send
+	 * @param player Player you want to send the message to
 	 */
 	
 	public void sendMessage(PrefixType type, String msg, Player player){

--- a/src/main/java/org/mcsg/survivalgames/SurvivalGames.java
+++ b/src/main/java/org/mcsg/survivalgames/SurvivalGames.java
@@ -36,7 +36,7 @@ public class SurvivalGames extends JavaPlugin {
 	public static List < String > auth = Arrays.asList(new String[] {
 			"Double0negative", "iMalo", "Medic0987", "alex_markey", "skitscape", "AntVenom", "YoshiGenius", "pimpinpsp", "WinryR", "Jazed2011",
 			"KiwiPantz", "blackracoon", "CuppingCakes", "4rr0ws", "Fawdz", "Timothy13", "rich91", "ModernPrestige", "Snowpool", "egoshk", 
-			"nickm140",  "chaseoes", "Oceangrass", "GrailMore", "iAngelic", "Lexonia", "ChaskyT", "Anon232", "IngeniousGamer", "ThunderGemios10", "sshipway" // List of Contributors
+			"nickm140",  "chaseoes", "Oceangrass", "GrailMore", "iAngelic", "Lexonia", "ChaskyT", "Anon232", "IngeniousGamer", "ThunderGemios10", "sshipway", "HeroCC" // List of Contributors
 	});
 
 	SurvivalGames p = this;

--- a/src/main/java/org/mcsg/survivalgames/commands/Reload.java
+++ b/src/main/java/org/mcsg/survivalgames/commands/Reload.java
@@ -15,7 +15,7 @@ public class Reload implements SubCommand{
 	public boolean onCommand(final Player player, String[] args) {
 		if(player.hasPermission(permission())){
 			if(args.length != 1){
-				MessageManager.getInstance().sendMessage(PrefixType.INFO, "Valid reload types <Settings | Games |All>", player);
+				MessageManager.getInstance().sendMessage(PrefixType.INFO, "Valid reload types <Settings | Games | All>", player);
 				MessageManager.getInstance().sendMessage(PrefixType.INFO, "Settings will reload the settings configs and attempt to reapply them", player);
 				MessageManager.getInstance().sendMessage(PrefixType.INFO, "Games will reload all games currently running", player);
 				MessageManager.getInstance().sendMessage(PrefixType.INFO, "All will attempt to reload the entire plugin", player);

--- a/src/main/java/org/mcsg/survivalgames/commands/SetLobbySpawn.java
+++ b/src/main/java/org/mcsg/survivalgames/commands/SetLobbySpawn.java
@@ -1,8 +1,8 @@
 package org.mcsg.survivalgames.commands;
 
-import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.mcsg.survivalgames.MessageManager;
+import org.mcsg.survivalgames.MessageManager.PrefixType;
 import org.mcsg.survivalgames.SettingsManager;
 
 
@@ -11,11 +11,11 @@ public class SetLobbySpawn implements SubCommand {
 
     public boolean onCommand(Player player, String[] args) {
         if (!player.hasPermission(permission()) && !player.isOp()) {
-            MessageManager.getInstance().sendFMessage(MessageManager.PrefixType.ERROR, "error.nopermission", player);
+            MessageManager.getInstance().sendFMessage(PrefixType.ERROR, "error.nopermission", player);
             return true;
         }
         SettingsManager.getInstance().setLobbySpawn(player.getLocation());
-        MessageManager.getInstance().sendMessage(MessageManager.PrefixType.INFO, "info.lobbyspawn", player);
+        MessageManager.getInstance().sendFMessage(PrefixType.INFO, "info.lobbyspawn", player);
         return true;
     }
     


### PR DESCRIPTION
This PR fixes misc typos (in README.md & help command), and corrects /sg setlobbyspawn not reporting the correct message. It also adds some javadoc improvements, and adds jrebel files to .gitignore.
