### PR TITLE
Fix Messages Typo

### DIFF
--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -47,7 +47,7 @@ messages:
     gamedisabled: '&cArena {$arena} is disabled!'
     joinmultiplegames: '&cCannot join multiple games!'
     notenoughplayers: '&cNot enough players to start!'
-    gamedosentexist: '&cArena {$arena} doesn''t exist!'
+    gamedoesntexist: '&cArena {$arena} doesn''t exist!'
     input: '&cInput error: {$message}'
     notingame: '&cMust be in a game to perform this action, or specify a game!'
     command: '&cThe command {$command} returned an error'

--- a/src/main/resources/messages_pl.yml
+++ b/src/main/resources/messages_pl.yml
@@ -46,7 +46,7 @@ messages:
     gamedisabled: '&cArena {$arena} jest wylaczona!'
     joinmultiplegames: '&cNie mozesz dolaczyc do wielu gier!'
     notenoughtplayers: '&cJest zamalo graczy by rozpoczac gre!'
-    gamedosentexist: '&cArena {$arena} nie istnieje!'
+    gamedoesntexist: '&cArena {$arena} nie istnieje!'
     input: '&cInput error: {$message}'
     notingame: '&cMusisz byc w grze by wykonac ta czynnosc!'
     command: '&cKomenda {$command} zwrocila blad'


### PR DESCRIPTION
Fix for error not showing properly in-game:
`Failed to load message for messages.error.gamedoesntexist`