### PR TITLE
Update default kits to support 1.17 material names

### DIFF
--- a/src/main/resources/kits.yml
+++ b/src/main/resources/kits.yml
@@ -44,14 +44,14 @@ kit-select-mode: 'SHOW_ALL'
 kits:
   test-kit:
     cost: 0
-    icon: 'WOOD_DOOR'
+    icon: 'OAK_DOOR'
     contents:
     - 'IRON_SWORD,1, 0, sharpness:4, Blade'
     - 'BOW'
     - 'ARROW, 64'
   kit2:
     cost: 0
-    icon: 'WOOD_DOOR'
+    icon: 'OAK_DOOR'
     contents:
     - 'STONE_SWORD,1, 0, fire:2, Fire'
     - 'BOW'


### PR DESCRIPTION
WOOD_DOOR is no longer a valid material name in 1.17